### PR TITLE
Invert logic after running which

### DIFF
--- a/lib/util-flow-command.coffee
+++ b/lib/util-flow-command.coffee
@@ -8,10 +8,11 @@ getFlowCommand = ->
   if not flowPath
     _flowCommand = spawnSync('which', ['flow']).stdout?.toString().trim()
     if _flowCommand
-      console.error "Could not find a 'flow' binary on your PATH, go to package settings and set 'Flow Path'"
-    else
       atom.config.set 'ide-flow.flowPath', _flowCommand
-      plowPath = _flowCommand
+      plowPath = _flowCommand      
+    else
+      console.error "Could not find a 'flow' binary on your PATH, go to package settings and set 'Flow Path'"
+
   return flowPath
 
 run = ({onMessage, onComplete, onFailure, args, cwd, input}) ->


### PR DESCRIPTION
The way this was written, if which found the executable, it would tell you it didn't, and similarly, if it didn't find the executable, it would tell you it did, thus causing an error.
